### PR TITLE
#46 Add DataSourceFacade#getContentParents method

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,6 +56,12 @@ dependencies {
     testImplementation 'org.mockftpserver:MockFtpServer:2.8.0'
     testImplementation 'it.ozimov:embedded-redis:0.7.3'
     testImplementation 'com.github.fppt:jedis-mock:0.1.22'
+    testImplementation 'org.testcontainers:postgresql:1.16.3'
+    testImplementation 'org.testcontainers:junit-jupiter:1.16.3'
+    testImplementation 'org.testcontainers:r2dbc:1.16.3'
+    testImplementation 'org.postgresql:postgresql:42.3.1'
+    testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'
+
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 

--- a/core/src/main/java/io/keepup/cms/core/config/DataSourceConfiguration.java
+++ b/core/src/main/java/io/keepup/cms/core/config/DataSourceConfiguration.java
@@ -38,9 +38,9 @@ public class DataSourceConfiguration {
      * @return component responsible for data source consistency check and update
      */
     @Bean
-    public SpringLiquibase liquibase() {
+    public SpringLiquibase liquibase(DataSource dataSource) {
         var liquibase = new SpringLiquibase();
-        liquibase.setDataSource(dataSource());
+        liquibase.setDataSource(dataSource);
         liquibase.setChangeLog(changeLog);
         liquibase.setShouldRun(liquibaseEnabled);
         return liquibase;

--- a/core/src/main/java/io/keepup/cms/core/datasource/dao/ContentDao.java
+++ b/core/src/main/java/io/keepup/cms/core/datasource/dao/ContentDao.java
@@ -27,6 +27,16 @@ public interface ContentDao {
     Flux<Content> getContentByParentIds(Iterable <Long> parentIds);
     Flux<Content> getContentByParentIdsAndType(Iterable <Long> parentIds, String type);
     Flux<Content> getContentByParentId(Long parentId);
+
+    /**
+     * Fetch a sequence of parents for the record specified by identifier. In current realization works only with
+     * PostgreSQL database as data source.
+     *
+     * @param id       child record identifier
+     * @param offsetId number of parent records to get
+     * @return         publisher for the parent records sequence
+     */
+    Flux<Content> getContentParents(Long id, Long offsetId);
     Mono<Long> createContent(Content content);
     Mono<Void> deleteContent(Long id);
 }

--- a/core/src/main/java/io/keepup/cms/core/datasource/dao/DataSourceFacade.java
+++ b/core/src/main/java/io/keepup/cms/core/datasource/dao/DataSourceFacade.java
@@ -31,6 +31,7 @@ public interface DataSourceFacade {
     Flux<Content> getContentByParentIds(Iterable <Long> parentIds);
     Flux<Content> getContentByParentIdsAndType(Iterable <Long> parentIds, String type);
     Flux<Content> getContentByParentId(Long parentId);
+    Flux<Content> getContentParents(Long id, Long offsetId);
     Mono<Long> createContent(Content content);
     Mono<Void> deleteContent(Long id);
     // endregion

--- a/core/src/main/java/io/keepup/cms/core/datasource/dao/DataSourceFacadeImpl.java
+++ b/core/src/main/java/io/keepup/cms/core/datasource/dao/DataSourceFacadeImpl.java
@@ -3,6 +3,8 @@ package io.keepup.cms.core.datasource.dao;
 import io.keepup.cms.core.persistence.Content;
 import io.keepup.cms.core.persistence.FileWrapper;
 import io.keepup.cms.core.persistence.User;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
@@ -95,6 +97,17 @@ public class DataSourceFacadeImpl implements DataSourceFacade {
     @Override
     public Flux<Content> getContentByParentId(Long parentId) {
         return contentDao.getContentByParentId(parentId);
+    }
+
+    /**
+     * Fetch a sequence of parents for the record specified by identifier.
+     * @param id       child record identifier, can not be null
+     * @param offsetId number of parent records to get, will be set to {@link Long#MAX_VALUE} if null
+     * @return         publisher for the parent records sequence
+     */
+    @Override
+    public Flux<Content> getContentParents(@NotNull Long id, @Nullable Long offsetId) {
+        return contentDao.getContentParents(id, offsetId);
     }
 
     @Override

--- a/core/src/test/java/io/keepup/cms/core/datasource/dao/PostgresContainerDataSourceTest.java
+++ b/core/src/test/java/io/keepup/cms/core/datasource/dao/PostgresContainerDataSourceTest.java
@@ -1,0 +1,141 @@
+package io.keepup.cms.core.datasource.dao;
+
+import io.keepup.cms.core.boot.KeepupApplication;
+import io.keepup.cms.core.cache.CacheAdapter;
+import io.keepup.cms.core.cache.KeepupCacheConfiguration;
+import io.keepup.cms.core.config.DataSourceConfiguration;
+import io.keepup.cms.core.config.R2dbcConfiguration;
+import io.keepup.cms.core.config.WebFluxConfig;
+import io.keepup.cms.core.datasource.dao.sql.SqlContentDao;
+import io.keepup.cms.core.datasource.dao.sql.SqlFileDao;
+import io.keepup.cms.core.datasource.dao.sql.SqlUserDao;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveNodeAttributeEntityRepository;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveNodeEntityRepository;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveUserEntityRepository;
+import io.keepup.cms.core.persistence.Content;
+import io.keepup.cms.core.persistence.Node;
+import io.r2dbc.spi.ConnectionFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"dev", "embedded-postgres"})
+@ContextConfiguration(
+        classes = {
+                KeepupApplication.class,
+                KeepupCacheConfiguration.class,
+                CacheAdapter.class,
+                WebFluxConfig.class,
+                ReactiveNodeEntityRepository.class,
+                ReactiveNodeAttributeEntityRepository.class,
+                ReactiveUserEntityRepository.class,
+                DataSourceConfiguration.class,
+                R2dbcConfiguration.class,
+                SqlContentDao.class,
+                SqlFileDao.class,
+                SqlUserDao.class,
+                DataSource.class,
+                DataSourceFacadeImpl.class,
+                ConnectionFactory.class
+        }
+)
+@TestPropertySource(properties = {
+        "spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver",
+        "spring.r2dbc.pool.enabled=true",
+        "spring.r2dbc.pool.initial-size=10",
+        "spring.r2dbc.pool.max-idle-time=1m",
+        "spring.r2dbc.pool.max-size=30",
+        "spring.data.r2dbc.repositories.enabled=true",
+})
+@Testcontainers
+class PostgresContainerDataSourceTest {
+
+    @Autowired
+    DataSourceFacade dataSourceFacade;
+
+    @Container
+    static PostgreSQLContainer postgres = new PostgreSQLContainer<>("postgres:11")
+            .withDatabaseName("keepup-db")
+                .withUsername("test")
+                .withPassword("test")
+                .withExposedPorts(5432);
+
+    @DynamicPropertySource
+    static void registerPgProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.jdbc-url",
+                () -> postgres.getJdbcUrl());
+        registry.add("spring.datasource.username", () -> "test");
+        registry.add("spring.datasource.password", () -> "test");
+        registry.add("spring.r2dbc.username", () -> "test");
+        registry.add(        "spring.r2dbc.password", () -> "test");
+        registry.add("spring.r2dbc.url", () -> "r2dbc:postgresql://localhost:%d/keepup-db?currentSchema=public&TC_DAEMON=true&TC_IMAGE_TAG=11.1".formatted(postgres.getFirstMappedPort()));
+    }
+
+    @Autowired
+    ReactiveNodeEntityRepository nodeEntityRepository;
+
+    @Test
+    void getContentParents() {
+        Content content = new Node();
+        content.setAttribute("parentNodeAttribute", "parent");
+        content.setParentId(0L);
+        content.setOwnerId(0L);
+        content.setDefaultPrivileges();
+        List<Content> parentRecords = dataSourceFacade.createContent(content)
+                .flatMap(parentId -> {
+                    Content child = new Node();
+                    child.setAttribute("childNodeAttribute", "child");
+                    child.setParentId(parentId);
+                    child.setOwnerId(0L);
+                    child.setDefaultPrivileges();
+                    return dataSourceFacade.createContent(child);
+                })
+                .flatMap(childId -> dataSourceFacade.getContentParents(childId, Long.MAX_VALUE).collectList())
+                .block();
+
+        assertNotNull(parentRecords);
+        assertFalse(parentRecords.isEmpty());
+        assertEquals(2, parentRecords.size());
+    }
+
+    @Test
+    void getContentParentsWithNullId() {
+        List<Content> parentRecords = dataSourceFacade.getContentParents(null, Long.MAX_VALUE).collectList()
+                .block();
+        assertNotNull(parentRecords);
+        assertTrue(parentRecords.isEmpty());
+    }
+
+    @Test
+    void getContentParentsWithNullOffset() {
+        Content content = new Node();
+        content.setAttribute("parentNodeAttribute", "parent");
+        content.setParentId(0L);
+        content.setOwnerId(0L);
+        content.setDefaultPrivileges();
+        List<Content> parentRecords = dataSourceFacade.createContent(content)
+                .flatMap(parentId -> {
+                    Content child = new Node();
+                    child.setAttribute("childNodeAttribute", "child");
+                    child.setParentId(parentId);
+                    child.setOwnerId(0L);
+                    child.setDefaultPrivileges();
+                    return dataSourceFacade.createContent(child);
+                })
+                .flatMap(childId -> dataSourceFacade.getContentParents(childId, null).collectList())
+                .block();
+        assertNotNull(parentRecords);
+        assertFalse(parentRecords.isEmpty());
+        assertEquals(2, parentRecords.size());
+    }
+}


### PR DESCRIPTION
fixes #46 

Also added Jupiter tests with testcontainers: https://www.testcontainers.org/

New functionality works only with PostgreSQL database as DAO uses special recursion in the query. If you try using H2, you get the BadSqlGrammarException.