### PR TITLE
#52 Implement method for getting the child node parents for H2 data source

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,8 +20,10 @@ jobs:
         distribution: 'adopt'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+    - name: Prepare admin UI static content
+      run: ./gradlew :admin-ui:deleteFiles :admin-ui:sb-admin:npmInstall :admin-ui:sb-admin:runBuild :admin-ui:copyFrontend
     - name: Build with Gradle
-      run: ./gradlew --info :admin-ui:deleteFiles :admin-ui:sb-admin:npmInstall :admin-ui:sb-admin:runBuild :admin-ui:copyFrontend build
+      run: ./gradlew build
     - name: Generate changelog
       run: ./gradlew generateGitChangelogInlineTemplate
     - name: JaCoCo

--- a/core/src/main/java/io/keepup/cms/core/datasource/dao/sql/H2ContentDao.java
+++ b/core/src/main/java/io/keepup/cms/core/datasource/dao/sql/H2ContentDao.java
@@ -1,0 +1,60 @@
+package io.keepup.cms.core.datasource.dao.sql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.keepup.cms.core.cache.CacheAdapter;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveNodeAttributeEntityRepository;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveNodeEntityRepository;
+import io.keepup.cms.core.persistence.Content;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+/**
+ * Service for working with {@link io.keepup.cms.core.persistence.Content} records using H2 database
+ * as data source. Can be used for demonstration properties, e.g. if you want to run the app without
+ * any additional components like production database.
+ *
+ * Service works in 'h2' profile.
+ *
+ * @author Fedor Sergeev
+ * @since  2.0.0
+ */
+@Service
+@Primary
+@Profile("h2")
+public class H2ContentDao extends SqlContentDao {
+    public H2ContentDao(ReactiveNodeEntityRepository reactiveNodeEntityRepository, ReactiveNodeAttributeEntityRepository reactiveNodeAttributeEntityRepository, ObjectMapper objectMapper, CacheManager manager, CacheAdapter adapter) {
+        super(reactiveNodeEntityRepository, reactiveNodeAttributeEntityRepository, objectMapper, manager, adapter);
+    }
+
+    /**
+     * Less effective method to fetch record parents, but it works for H2 database. Fetches all {@link Content} records
+     * until the root or the specified offset record is found. Yet this method does not put found records in cache.
+     *
+     * @param id     first parent record identifier, in case of null empty Flux will be returned
+     * @param offset depth of search, in case of null will be set to {@link Long#MAX_VALUE}
+     * @return       publisher for the sequence of records inheriting each other till the record with the specified
+     *               parent id (excluding this record itself)
+     */
+    @Override
+    public Flux<Content> getContentParents(@NotNull Long id, @Nullable Long offset) {
+        // left this check for public API users who don't use any lint tools
+        if (id == null) {
+            getLog().error("Null parameter id was passed to getContentParents method");
+            return Flux.empty();
+        }
+        int capacity = offset == null || offset > Integer.MAX_VALUE
+            ? Integer.MAX_VALUE
+            : offset.intValue();
+
+        return getNodeEntityRepository().findById(id)
+                .flatMap(entity -> getNodeEntityRepository().findById(entity.getParentId()))
+                .expand(nodeEntity -> getNodeEntityRepository().findById(nodeEntity.getParentId()), capacity)
+                .take(capacity)
+                .flatMap(getNodeEntityPublisherFunction());
+    }
+}

--- a/core/src/main/java/io/keepup/cms/core/datasource/dao/sql/SqlContentDao.java
+++ b/core/src/main/java/io/keepup/cms/core/datasource/dao/sql/SqlContentDao.java
@@ -408,7 +408,7 @@ public class SqlContentDao implements ContentDao {
     // endregion
 
     @NotNull
-    private Function<NodeEntity, Publisher<? extends Content>> getNodeEntityPublisherFunction() {
+    protected Function<NodeEntity, Publisher<Content>> getNodeEntityPublisherFunction() {
         return nodeEntity -> nodeAttributeEntityRepository.findAllByContentId(nodeEntity.getId())
                 .collectList()
                 .map(nodeAttributeEntities -> buildNode(nodeEntity, nodeAttributeEntities))
@@ -497,6 +497,18 @@ public class SqlContentDao implements ContentDao {
         return null;
     }
 
+    Log getLog() {
+        return log;
+    }
+
+    ReactiveNodeEntityRepository getNodeEntityRepository() {
+        return nodeEntityRepository;
+    }
+
+    ReactiveNodeAttributeEntityRepository getNodeAttributeEntityRepository() {
+        return nodeAttributeEntityRepository;
+    }
+
     Content buildNode(NodeEntity nodeEntity, List<NodeAttributeEntity> attributeEntities) {
         // as we call this method from reactive chain there is no success result with null NodeEntity
         final Content content = new Node(nodeEntity.getId());
@@ -560,10 +572,7 @@ public class SqlContentDao implements ContentDao {
      * @param parameterName parameter object name in context
      * @return variable name in case it is null
      */
-    private String getNullParameterName(Object parameter, String parameterName) {
-        if (parameterName == null) {
-            return "null";
-        }
+    private String getNullParameterName(Object parameter, @NotNull String parameterName) {
         return parameter == null
                 ? parameterName
                 : EMPTY;

--- a/core/src/main/java/io/keepup/cms/core/datasource/sql/repository/ReactiveNodeAttributeEntityRepository.java
+++ b/core/src/main/java/io/keepup/cms/core/datasource/sql/repository/ReactiveNodeAttributeEntityRepository.java
@@ -31,16 +31,13 @@ public interface ReactiveNodeAttributeEntityRepository extends ReactiveCrudRepos
      * @param attributeNames number of attribute names
      * @return all node attributes for the specified by condition {@link Content} nodes
      */
-    @Query("SELECT * " +
+    @Query("SELECT id, content_id, attribute_key, attribute_value,  java_class " +
            "FROM node_attribute AS nodeAttribute " +
            "WHERE nodeAttribute.content_id " +
            "IN (SELECT content_id FROM node_attribute " +
-           "    AS attribute  " +
-           "    WHERE attribute.content_id " +
-           "    IN (SELECT id FROM node_entity " +
-           "        AS node " +
-           "        WHERE node.parent_id = :contentParentId) " +
-           "    AND attribute.attribute_key in (:attributeNames))")
+           "   inner join node_entity on (node_attribute.content_id = node_entity.id " +
+           "   and node_entity.parent_id = :contentParentId" +
+           "   and node_attribute.attribute_key in (:attributeNames)))")
     Flux<NodeAttributeEntity> findAllByContentParentIdWithAttributeNames(@Param("contentParentId") Long parentId,
                                                                          @Param("attributeNames") List<String> attributeNames);
 
@@ -51,7 +48,7 @@ public interface ReactiveNodeAttributeEntityRepository extends ReactiveCrudRepos
      * @param attributeValue attribute field value
      * @return all node attributes for the specified by condition {@link Content} nodes
      */
-    @Query("SELECT * " +
+    @Query("SELECT id, content_id, attribute_key, attribute_value,  java_class " +
             "FROM node_attribute AS nodeAttribute " +
             "WHERE nodeAttribute.content_id " +
             "IN (SELECT content_id FROM node_attribute " +

--- a/core/src/main/java/io/keepup/cms/core/datasource/sql/repository/ReactiveNodeEntityRepository.java
+++ b/core/src/main/java/io/keepup/cms/core/datasource/sql/repository/ReactiveNodeEntityRepository.java
@@ -54,6 +54,13 @@ public interface ReactiveNodeEntityRepository extends ReactiveCrudRepository<Nod
             "FROM node_entity as node WHERE node.id = :id OR node.parent_id = :id")
     Flux<NodeEntity> findByIdOrByParentId(@Param("id") Long id);
 
+    /**
+     * Fetches the sequence of parent records. Use this method only for PostgreSQL as a database.
+     *
+     * @param id     record identifier
+     * @param offset number of parent records to fetch
+     * @return       Flux that publishes found entity parents
+     */
     @Query("WITH RECURSIVE r AS (" +
             "   SELECT id, parent_id, owner_id, entity_type, " +
             "   owner_read_privilege, owner_write_privilege, owner_create_children_privilege, owner_execute_privilege," +

--- a/core/src/test/java/io/keepup/cms/core/datasource/dao/sql/H2ContentDaoTest.java
+++ b/core/src/test/java/io/keepup/cms/core/datasource/dao/sql/H2ContentDaoTest.java
@@ -1,0 +1,141 @@
+package io.keepup.cms.core.datasource.dao.sql;
+
+import io.keepup.cms.core.boot.KeepupApplication;
+import io.keepup.cms.core.cache.CacheAdapter;
+import io.keepup.cms.core.cache.KeepupCacheConfiguration;
+import io.keepup.cms.core.config.DataSourceConfiguration;
+import io.keepup.cms.core.config.R2dbcConfiguration;
+import io.keepup.cms.core.config.WebFluxConfig;
+import io.keepup.cms.core.datasource.sql.H2ConsoleService;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveNodeAttributeEntityRepository;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveNodeEntityRepository;
+import io.keepup.cms.core.datasource.sql.repository.ReactiveUserEntityRepository;
+import io.keepup.cms.core.persistence.Content;
+import io.keepup.cms.core.persistence.Node;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles({"dev", "h2"})
+@ContextConfiguration(classes = {
+        KeepupApplication.class,
+        KeepupCacheConfiguration.class,
+        CacheAdapter.class,
+        WebFluxConfig.class,
+        ReactiveNodeEntityRepository.class,
+        ReactiveNodeAttributeEntityRepository.class,
+        ReactiveUserEntityRepository.class,
+        DataSourceConfiguration.class,
+        H2ConsoleService.class,
+        H2ConsoleService.class,
+        R2dbcConfiguration.class,
+        H2ContentDao.class,
+})
+@DataR2dbcTest
+class H2ContentDaoTest {
+
+    @Autowired
+    H2ContentDao h2ContentDao;
+
+    @Test
+    void getContentParents() {
+        h2ContentDao.getNodeAttributeEntityRepository().deleteAll()
+                .then(h2ContentDao.getNodeEntityRepository().deleteAll())
+                .then(h2ContentDao.createContent(createRecord(0L, Pair.of("key", "firstParent"))))
+                .flatMap(grandParent -> h2ContentDao.createContent(createRecord(grandParent, Pair.of("key", "secondParent"))))
+                .flatMap(parent -> h2ContentDao.createContent(createRecord(parent, Pair.of("key", "child"))))
+                .flatMap(childId -> h2ContentDao.getContentParents(childId, 2L).collectList())
+                .doOnNext(parents -> {
+                    assertNotNull(parents);
+                    assertFalse(parents.isEmpty());
+                    assertEquals(2, parents.size());
+                    assertEquals(parents.get(0).getParentId(), parents.get(1).getId());
+                    assertEquals(0, parents.get(1).getParentId());
+                })
+                .block();
+    }
+
+    @Test
+    void getContentParentsByNullId() {
+        h2ContentDao.getNodeAttributeEntityRepository().deleteAll()
+                .then(h2ContentDao.getNodeEntityRepository().deleteAll())
+                .then(h2ContentDao.createContent(createRecord(0L, Pair.of("key", "firstParent"))))
+                .flatMap(grandParent -> h2ContentDao.createContent(createRecord(grandParent, Pair.of("key", "secondParent"))))
+                .flatMap(parent -> h2ContentDao.createContent(createRecord(parent, Pair.of("key", "child"))))
+                .then(h2ContentDao.getContentParents(null, 2L).collectList())
+                .doOnNext(parents -> {
+                    assertNotNull(parents);
+                    assertTrue(parents.isEmpty());
+                })
+                .block();
+    }
+
+    @Test
+    void getContentParentsByNullOffset() {
+        h2ContentDao.getNodeAttributeEntityRepository().deleteAll()
+                .then(h2ContentDao.getNodeEntityRepository().deleteAll())
+                .then(h2ContentDao.createContent(createRecord(0L, Pair.of("key", "firstParent"))))
+                .flatMap(grandParent -> h2ContentDao.createContent(createRecord(grandParent, Pair.of("key", "secondParent"))))
+                .flatMap(parent -> h2ContentDao.createContent(createRecord(parent, Pair.of("key", "child"))))
+                .flatMap(childId -> h2ContentDao.getContentParents(childId, null).collectList())
+                .doOnNext(parents -> {
+                    assertNotNull(parents);
+                    assertFalse(parents.isEmpty());
+                    assertEquals(2, parents.size());
+                    assertEquals(parents.get(0).getParentId(), parents.get(1).getId());
+                    assertEquals(0, parents.get(1).getParentId());
+                })
+                .block();
+    }
+
+    @Test
+    void getContentParentsByVeryLongOffset() {
+        h2ContentDao.getNodeAttributeEntityRepository().deleteAll()
+                .then(h2ContentDao.getNodeEntityRepository().deleteAll())
+                .then(h2ContentDao.createContent(createRecord(0L, Pair.of("key", "firstParent"))))
+                .flatMap(grandParent -> h2ContentDao.createContent(createRecord(grandParent, Pair.of("key", "secondParent"))))
+                .flatMap(parent -> h2ContentDao.createContent(createRecord(parent, Pair.of("key", "child"))))
+                .flatMap(childId -> h2ContentDao.getContentParents(childId, Long.MAX_VALUE).collectList())
+                .doOnNext(parents -> {
+                    assertNotNull(parents);
+                    assertFalse(parents.isEmpty());
+                    assertEquals(2, parents.size());
+                    assertEquals(parents.get(0).getParentId(), parents.get(1).getId());
+                    assertEquals(0, parents.get(1).getParentId());
+                })
+                .block();
+    }
+
+    @Test
+    void getContentParentsByOffsetIsOne() {
+        h2ContentDao.getNodeAttributeEntityRepository().deleteAll()
+                .then(h2ContentDao.getNodeEntityRepository().deleteAll())
+                .then(h2ContentDao.createContent(createRecord(0L, Pair.of("key", "firstParent"))))
+                .flatMap(grandParent -> h2ContentDao.createContent(createRecord(grandParent, Pair.of("key", "secondParent"))))
+                .flatMap(parent -> h2ContentDao.createContent(createRecord(parent, Pair.of("key", "child"))))
+                .flatMap(childId -> h2ContentDao.getContentParents(childId, 1L).collectList())
+                .doOnNext(parents -> {
+                    assertNotNull(parents);
+                    assertFalse(parents.isEmpty());
+                    assertEquals(1, parents.size());
+                })
+                .block();
+    }
+
+    Content createRecord(long parentId, Pair<String, String> attribute) {
+        Content node = new Node();
+        node.setDefaultPrivileges();
+        node.setParentId(parentId);
+        node.setOwnerId(0L);
+        node.setAttribute(attribute.getLeft(), attribute.getRight());
+        return  node;
+    }
+}

--- a/core/src/test/java/io/keepup/cms/core/datasource/dao/sql/SqlContentDaoTest.java
+++ b/core/src/test/java/io/keepup/cms/core/datasource/dao/sql/SqlContentDaoTest.java
@@ -6,6 +6,7 @@ import io.keepup.cms.core.cache.CacheAdapter;
 import io.keepup.cms.core.datasource.sql.entity.NodeAttributeEntity;
 import io.keepup.cms.core.datasource.sql.repository.ReactiveNodeAttributeEntityRepository;
 import io.keepup.cms.core.datasource.sql.repository.ReactiveNodeEntityRepository;
+import io.keepup.cms.core.persistence.Content;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,8 +18,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.CacheManager;
 import reactor.core.publisher.Mono;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Additional unit tests
@@ -38,6 +40,10 @@ class SqlContentDaoTest {
     CacheManager manager;
     @Mock
     CacheAdapter adapter;
+
+    private static void assertEmpty(List<Content> result) {
+        assertTrue(result.isEmpty());
+    }
 
     @BeforeEach
     void setUp() {
@@ -63,6 +69,22 @@ class SqlContentDaoTest {
                     assertNotNull(result);
                     assertEquals("value", result);
                 })
+                .block();
+    }
+
+    @Test
+    void getContentByParentIdAndAttributeValueWithNullParentId() {
+        sqlContentDao.getContentByParentIdAndAttributeValue(null, "key", "value")
+                .collectList()
+                .doOnNext(result -> assertTrue(result.isEmpty()))
+                .block();
+    }
+
+    @Test
+    void getContentByParentIdAndAttributeValueWithNullAttributeKey() {
+        sqlContentDao.getContentByParentIdAndAttributeValue(0L, null, "value")
+                .collectList()
+                .doOnNext(SqlContentDaoTest::assertEmpty)
                 .block();
     }
 }


### PR DESCRIPTION
Fixes #52 

As H2 does not support PostgreSQL recursive queries, we need to implement functionality for emitting the specified content record parents for this type of data source.

H2 can be used as a master db in case when you want to run an application (doesn't matter containerized or not) as the only component for demonstration purposes.

Records that are being emitted aren't stored in Content cache.

There is a couple of small SQL code optimizations.